### PR TITLE
Adjust HTML for FreeBSD logo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ We’re proud to be supported by:
 
 <p align="center">
   <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="./docs/sponsors/FreeBSD-White.png">
-        <img src="./docs/sponsors/FreeBSD-Red.png" alt="FreeBSD Foundation" width="200"/>
+    <source media="(prefers-color-scheme: dark)" srcset="./docs/sponsors/FreeBSD-White.png">
+    <img src="./docs/sponsors/FreeBSD-Red.png" alt="FreeBSD Foundation" width="200"/>
   </picture>
   &emsp;&emsp;&emsp;
   <a href="https://alchemilla.io">


### PR DESCRIPTION
Minor. Adjust HTML indenting for the FreeBSD logo.
:sweat_smile: :shrug: :zany_face:

Since the FreeBSD logo doesn't have an anchor tag, the source and img tags ([lines 20-21](https://github.com/AlchemillaHQ/Sylve/blob/0ffe3b1673a67b9bdb6a047c6720b2009aab52c0/README.md?plain=1#L21)) don't need to be indented as far (as lines 26-27).

(Essentially the first source/img tag would only indent as far as the second set of picture tags.)

> [!NOTE]
> At commit 0ffe3b1, the line numbers differ (21-22 and 28-29).
> The line numbers mentioned above are as of 27cdb45