### PR TITLE
Helpers: make the req pkgs error message DRY

### DIFF
--- a/internal/services/startup/helpers.go
+++ b/internal/services/startup/helpers.go
@@ -100,7 +100,10 @@ func (s *Service) CheckPackageDependencies() error {
 		go func() {
 			defer wg.Done()
 			if !pkg.IsPackageInstalled(p) {
-				errCh <- fmt.Errorf("Required package %s is not installed, run the command 'pkg install libvirt bhyve-firmware smartmontools tmux samba419 jansson swtpm' to install all required packages", p)
+				errCh <- fmt.Errorf(
+					"Required package %s is not installed, run the command 'pkg install %s' to install all required packages",
+					p, strings.Join(requiredPackages, " ")
+				)
 			}
 		}()
 	}


### PR DESCRIPTION
enhancement to #41

* Make the "required packages" error message DRY
* Programmatically generate the package list string so that later if a new dependency is added the error message will not need updated! :tada: :slightly_smiling_face:


***Draft PR for now since I need to build a test environment and run the modified code. :relaxed:***