### PR TITLE
Libvirt startup fixes

### DIFF
--- a/internal/interfaces/services/libvirt/libvirt.go
+++ b/internal/interfaces/services/libvirt/libvirt.go
@@ -82,6 +82,7 @@ type LibvirtServiceInterface interface {
 	GetDomainState(rid int) (libvirt.DomainState, error)
 
 	CheckVersion() error
+	IsVirtualizationEnabled() bool
 }
 
 type LvDomain struct {

--- a/internal/services/network/objects.go
+++ b/internal/services/network/objects.go
@@ -509,7 +509,7 @@ func (s *Service) EditObject(id uint, name string, oType string, values []string
 					}
 				}
 
-				if s.LibVirt != nil {
+				if s.LibVirt.IsVirtualizationEnabled() {
 					active, err := s.LibVirt.IsDomainInactive(vm.RID)
 
 					if err != nil {
@@ -544,7 +544,7 @@ func (s *Service) EditObject(id uint, name string, oType string, values []string
 					}
 				}
 
-				if s.LibVirt != nil {
+				if s.LibVirt.IsVirtualizationEnabled() {
 					err = s.LibVirt.FindAndChangeMAC(vm.RID, object.Entries[0].Value, values[0])
 					if err != nil {
 						return fmt.Errorf("failed to change MAC address in VM %d: %w", vm.RID, err)

--- a/internal/services/startup/helpers.go
+++ b/internal/services/startup/helpers.go
@@ -88,7 +88,6 @@ func (s *Service) FreeBSDCheck() error {
 
 func (s *Service) CheckPackageDependencies(basicSettings models.BasicSettings) error {
 	requiredPackages := []string{
-		"smartmontools",
 		"tmux",
 	}
 


### PR DESCRIPTION
We tried to use a libvirt RPC connection before the db was init, now it defers until we have a record