### PR TITLE
Fix explanation comment in rc.d script

### DIFF
--- a/docs/app-docs/src/content/docs/getting-started.mdx
+++ b/docs/app-docs/src/content/docs/getting-started.mdx
@@ -185,9 +185,9 @@ Now that we have both the config and data directories setup, we can create an `r
 #
 # sylve_enable (bool):      Set to "NO" by default.
 #                           Set it to "YES" to enable sylve.
-# sylve_user (user):        Set to "www" by default.
+# sylve_user (user):        Set to "root" by default.
 #                           User to run sylve as.
-# sylve_group (group):      Set to "www" by default.
+# sylve_group (group):      Set to "wheel" by default.
 #                           Group to run sylve as.
 # sylve_args (str):         Set to "-config %%ETCDIR%%/config.json" by default.
 #                           Extra flags passed to sylve.


### PR DESCRIPTION
The explanation now reflects reality few lines lower.