### PR TITLE
Check for qemu-img executable instead of qemu-tools package.

### DIFF
--- a/internal/services/system/basic_checks.go
+++ b/internal/services/system/basic_checks.go
@@ -37,7 +37,6 @@ func (s *Service) CheckVirtualization() error {
 		"bhyve-firmware",
 		"u-boot-bhyve-arm64",
 		"swtpm",
-		"qemu-tools",
 	}
 
 	for _, p := range requiredPackages {
@@ -58,7 +57,11 @@ func (s *Service) CheckVirtualization() error {
 		}
 	}
 
-	if _,err := utils.RunCommand("/sbin/kldstat", "-m", "vmm"); err == nil {
+	if !utils.HasCmd("qemu-img") {
+		return fmt.Errorf("virt_required_command_qemu-img_not_found")
+	}
+
+	if _, err := utils.RunCommand("/sbin/kldstat", "-m", "vmm"); err == nil {
 		return nil
 	}
 


### PR DESCRIPTION
Both qemu and qemu-tools provide qemu-img, but the packages conflict with each other, so the virtualization check failed on hosts that have qemu installed even though qemu-img is available. Check for the executable on PATH instead, matching how it is actually invoked.