### PR TITLE
docs: jailing-sylve: Fix devfs_ruleset id

### DIFF
--- a/docs/app-docs/src/content/docs/guides/advanced-topics/jailing-sylve/index.mdx
+++ b/docs/app-docs/src/content/docs/guides/advanced-topics/jailing-sylve/index.mdx
@@ -14,7 +14,7 @@ This is not extensively tested but a cool thing to try out nonetheless. If you h
 To run Sylve inside a jail environment, allow the permissions below and adjust the settings as shown:
 
 ```
-devfs_ruleset=5;
+devfs_ruleset=6;
 allow.vmm;
 allow.nfsd;
 allow.mount;


### PR DESCRIPTION
The `devfs_ruleset` should be `6`, matching the ID in the DevFS section.