### PR TITLE
network: switch: std: tolerate inet6 -alias EPERM when bridging a port in a jail

### DIFF
--- a/internal/services/network/switch_standard.go
+++ b/internal/services/network/switch_standard.go
@@ -1078,8 +1078,12 @@ func addBridgeMember(br, portName string, mtu, vlan int, disableOffloads bool) e
 		if _, err := syncRunCommand("/sbin/ifconfig", port, "inet", "-alias"); err != nil {
 			return fmt.Errorf("clear inet on %s: %v", port, err)
 		}
+		// An IPv4-only (VNET) jail rejects deleting an IPv6 address with
+		// EPERM ("permission denied"); there is nothing to clear in that
+		// case, so treat it as non-fatal like the "no address" case above.
 		if _, err := syncRunCommand("/sbin/ifconfig", port, "inet6", "-alias"); err != nil &&
-			!strings.Contains(err.Error(), "Can't assign requested address") {
+			!strings.Contains(err.Error(), "Can't assign requested address") &&
+			!strings.Contains(err.Error(), "permission denied") {
 			return fmt.Errorf("clear inet6 on %s: %v", port, err)
 		}
 	}

--- a/internal/services/network/switch_standard_test.go
+++ b/internal/services/network/switch_standard_test.go
@@ -2127,3 +2127,31 @@ func TestStandardSwitchDeletePreflightDetectsSambaInterfaceUsage(t *testing.T) {
 		t.Fatalf("unexpected error code: %q", code)
 	}
 }
+
+// A bridged switch with a port must still be creatable inside an IPv4-only
+// (VNET) jail, where deleting an IPv6 alias on the port returns EPERM.
+func TestCreateStandardBridgeToleratesPortInet6PermissionDenied(t *testing.T) {
+	stubSyncFunctions(t, syncStubSet{
+		runCommand: func(command string, args ...string) (string, error) {
+			full := strings.Join(append([]string{command}, args...), " ")
+			if full == "/sbin/ifconfig bridge create" {
+				return "bridge200\n", nil
+			}
+			if full == "/sbin/ifconfig em0 inet6 -alias" {
+				return "", fmt.Errorf("command execution failed: exit status 1, " +
+					"output: ifconfig: ioctl (SIOCDIFADDR): permission denied")
+			}
+			return "", nil
+		},
+	})
+
+	sw := networkModels.StandardSwitch{
+		Name:        "jail-port",
+		BridgeName:  "vm-jail-port",
+		DisableIPv6: true,
+		Ports:       []networkModels.NetworkPort{{Name: "em0"}},
+	}
+	if err := createStandardBridge(sw); err != nil {
+		t.Fatalf("expected create to tolerate inet6 -alias permission denied, got %v", err)
+	}
+}


### PR DESCRIPTION
Creating a bridged switch with a port runs `ifconfig <port> inet6 -alias` before adding the port to the bridge. Inside an IPv4-only VNET jail, deleting an IPv6 address returns EPERM ("permission denied"), so createStandardBridge fails with "clear inet6 on <port>: ... SIOCDIFADDR): permission denied" and no bridged switch can be created in a jail.

Tolerate the permission-denied error the same way the existing code already tolerates "Can't assign requested address"

Jailed Sylve (container) with the fix: a bridged switch created successfully, and VM 100 pulls a real DHCP lease from the LAN - guest em0 = 192.168.86.236, bridged out the host's bridge1 (re0 + epair1a). Without this fix, creating that bridged switch fails on inet6 -alias EPERM.
<img width="1709" height="1065" alt="feae13fa-3aa6-4272-8b36-a4eafaa173f6" src="https://github.com/user-attachments/assets/41741d6c-172b-47f5-9cef-66336e2409c9" />
