### PR TITLE
ui: sidebar: search, expand/collapse all, quick actions

### DIFF
--- a/web/src/lib/components/skeleton/LeftPanel.svelte
+++ b/web/src/lib/components/skeleton/LeftPanel.svelte
@@ -15,6 +15,7 @@
 	import {
 		buildResourceTree,
 		collectResourceTreeIds,
+		filterResourceTree,
 		type ResourceTreePreferences,
 		type ResourceTreeResource,
 		type ResourceTreeView
@@ -25,9 +26,10 @@
 
 	interface Props {
 		preferences: ResourceTreePreferences;
+		searchQuery?: string;
 	}
 
-	let { preferences }: Props = $props();
+	let { preferences, searchQuery = '' }: Props = $props();
 
 	let openIdsByView = $state<Record<ResourceTreeView, Set<string>>>({
 		server: loadOpenIds('single', 'server'),
@@ -51,6 +53,20 @@
 		openIdsByView = { ...openIdsByView, [view]: nextOpenIds };
 		saveOpenIds(nextOpenIds, 'single', view);
 	};
+
+	export function expandAll() {
+		const view = preferences.view;
+		const nextOpenIds = new Set(collectResourceTreeIds(tree));
+		openIdsByView = { ...openIdsByView, [view]: nextOpenIds };
+		saveOpenIds(nextOpenIds, 'single', view);
+	}
+
+	export function collapseAll() {
+		const view = preferences.view;
+		const nextOpenIds = new Set<string>();
+		openIdsByView = { ...openIdsByView, [view]: nextOpenIds };
+		saveOpenIds(nextOpenIds, 'single', view);
+	}
 
 	let node = $derived.by(() => {
 		const routeHost = page.url.pathname.split('/').filter(Boolean)[0] || '';
@@ -226,6 +242,16 @@
 		})
 	);
 
+	let displayTree = $derived(searchQuery.trim() ? filterResourceTree(tree, searchQuery) : tree);
+	let searching = $derived(searchQuery.trim().length > 0);
+	let effectiveOpenIds = $derived(
+		searching ? new Set(collectResourceTreeIds(displayTree)) : openIds
+	);
+	function effectiveToggleOpen(id: string) {
+		if (searching) return;
+		toggleOpen(id);
+	}
+
 	let resourcesReady = $derived(
 		!simpleVMs.loading &&
 			!simpleJails.loading &&
@@ -315,9 +341,24 @@
 	<nav aria-label="sylve-sidebar" class="menu thin-scrollbar h-full min-h-0 w-full">
 		<ul class="h-full min-h-0">
 			<ScrollArea orientation="both" class="h-full w-full">
-				{#each tree as item (item.id)}
-					<TreeViewCluster {item} {openIds} onToggleId={toggleOpen} {nextGuestId} />
-				{/each}
+				{#if searching && displayTree.length === 0}
+					<div
+						class="text-muted-foreground flex flex-col items-center gap-1.5 px-2 py-8 text-center text-xs"
+					>
+						<span class="icon-[lucide--search-x] size-5"></span>
+						<span>No matches for &ldquo;{searchQuery}&rdquo;</span>
+					</div>
+				{:else}
+					{#each displayTree as item (item.id)}
+						<TreeViewCluster
+							{item}
+							openIds={effectiveOpenIds}
+							onToggleId={effectiveToggleOpen}
+							{nextGuestId}
+							density={preferences.density}
+						/>
+					{/each}
+				{/if}
 			</ScrollArea>
 		</ul>
 	</nav>

--- a/web/src/lib/components/skeleton/LeftPanelClustered.svelte
+++ b/web/src/lib/components/skeleton/LeftPanelClustered.svelte
@@ -6,6 +6,7 @@
 	import {
 		buildResourceTree,
 		collectResourceTreeIds,
+		filterResourceTree,
 		type ResourceTreeNodeInput,
 		type ResourceTreeItem,
 		type ResourceTreePreferences,
@@ -38,9 +39,10 @@
 
 	interface Props {
 		preferences: ResourceTreePreferences;
+		searchQuery?: string;
 	}
 
-	let { preferences }: Props = $props();
+	let { preferences, searchQuery = '' }: Props = $props();
 
 	const emptyClusterSidebarSnapshot: ClusterSidebarSnapshot = {
 		resources: [],
@@ -68,6 +70,20 @@
 		openIdsByView = { ...openIdsByView, [view]: nextOpenIds };
 		saveOpenIds(nextOpenIds, 'cluster', view);
 	};
+
+	export function expandAll() {
+		const view = preferences.view;
+		const nextOpenIds = new Set(collectResourceTreeIds(tree));
+		openIdsByView = { ...openIdsByView, [view]: nextOpenIds };
+		saveOpenIds(nextOpenIds, 'cluster', view);
+	}
+
+	export function collapseAll() {
+		const view = preferences.view;
+		const nextOpenIds = new Set<string>();
+		openIdsByView = { ...openIdsByView, [view]: nextOpenIds };
+		saveOpenIds(nextOpenIds, 'cluster', view);
+	}
 
 	async function refetchClusterResources() {
 		await clusterSidebarSnapshot.refetch();
@@ -245,6 +261,16 @@
 		})
 	);
 
+	let displayTree = $derived(searchQuery.trim() ? filterResourceTree(tree, searchQuery) : tree);
+	let searching = $derived(searchQuery.trim().length > 0);
+	let effectiveOpenIds = $derived(
+		searching ? new Set(collectResourceTreeIds(displayTree)) : openIds
+	);
+	function effectiveToggleOpen(id: string) {
+		if (searching) return;
+		toggleOpen(id);
+	}
+
 	let resourcesReady = $derived(!clusterSidebarSnapshot.loading);
 
 	watch(
@@ -312,15 +338,25 @@
 	<nav aria-label="sylve-sidebar" class="menu thin-scrollbar h-full min-h-0 w-full">
 		<ul class="h-full min-h-0">
 			<ScrollArea orientation="both" class="h-full w-full">
-				{#each tree as item (item.id)}
-					<TreeViewCluster
-						{item}
-						{openIds}
-						onToggleId={toggleOpen}
-						{canMigrate}
-						onMigrate={openMigration}
-					/>
-				{/each}
+				{#if searching && displayTree.length === 0}
+					<div
+						class="text-muted-foreground flex flex-col items-center gap-1.5 px-2 py-8 text-center text-xs"
+					>
+						<span class="icon-[lucide--search-x] size-5"></span>
+						<span>No matches for &ldquo;{searchQuery}&rdquo;</span>
+					</div>
+				{:else}
+					{#each displayTree as item (item.id)}
+						<TreeViewCluster
+							{item}
+							openIds={effectiveOpenIds}
+							onToggleId={effectiveToggleOpen}
+							{canMigrate}
+							onMigrate={openMigration}
+							density={preferences.density}
+						/>
+					{/each}
+				{/if}
 			</ScrollArea>
 		</ul>
 	</nav>

--- a/web/src/lib/components/skeleton/ResourceTreeToolbar.svelte
+++ b/web/src/lib/components/skeleton/ResourceTreeToolbar.svelte
@@ -3,10 +3,12 @@
 	import SpanWithIcon from '$lib/components/custom/SpanWithIcon.svelte';
 	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
 	import * as Dialog from '$lib/components/ui/dialog/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
 	import * as Select from '$lib/components/ui/select/index.js';
 	import {
 		DEFAULT_RESOURCE_TREE_PREFERENCES,
+		type ResourceTreeDensity,
 		type ResourceTreePreferences,
 		type ResourceTreeSortKey,
 		type ResourceTreeView
@@ -15,18 +17,22 @@
 	interface Props {
 		preferences: ResourceTreePreferences;
 		onChange: (preferences: ResourceTreePreferences) => void;
+		searchQuery: string;
+		onSearchChange: (value: string) => void;
+		onExpandAll: () => void;
+		onCollapseAll: () => void;
 	}
 
-	let { preferences, onChange }: Props = $props();
+	let { preferences, onChange, searchQuery, onSearchChange, onExpandAll, onCollapseAll }: Props =
+		$props();
 
 	let settingsOpen = $state(false);
 	let draftSortKey = $state<ResourceTreeSortKey>(DEFAULT_RESOURCE_TREE_PREFERENCES.sortKey);
 	let draftGroupTemplates = $state(DEFAULT_RESOURCE_TREE_PREFERENCES.groupTemplates);
 	let draftGroupGuestTypes = $state(DEFAULT_RESOURCE_TREE_PREFERENCES.groupGuestTypes);
+	let draftDensity = $state<ResourceTreeDensity>(DEFAULT_RESOURCE_TREE_PREFERENCES.density);
 
-	let selectedViewLabel = $derived(
-		preferences.view === 'folder' ? 'Folder View' : 'Server View'
-	);
+	let selectedViewLabel = $derived(preferences.view === 'folder' ? 'Folder View' : 'Server View');
 
 	function changeView(value: string | undefined) {
 		if (value !== 'server' && value !== 'folder') return;
@@ -37,6 +43,7 @@
 		draftSortKey = preferences.sortKey;
 		draftGroupTemplates = preferences.groupTemplates;
 		draftGroupGuestTypes = preferences.groupGuestTypes;
+		draftDensity = preferences.density;
 		settingsOpen = true;
 	}
 
@@ -44,6 +51,7 @@
 		draftSortKey = DEFAULT_RESOURCE_TREE_PREFERENCES.sortKey;
 		draftGroupTemplates = DEFAULT_RESOURCE_TREE_PREFERENCES.groupTemplates;
 		draftGroupGuestTypes = DEFAULT_RESOURCE_TREE_PREFERENCES.groupGuestTypes;
+		draftDensity = DEFAULT_RESOURCE_TREE_PREFERENCES.density;
 	}
 
 	function saveSettings() {
@@ -51,7 +59,8 @@
 			...preferences,
 			sortKey: draftSortKey,
 			groupTemplates: draftGroupTemplates,
-			groupGuestTypes: draftGroupGuestTypes
+			groupGuestTypes: draftGroupGuestTypes,
+			density: draftDensity
 		});
 		settingsOpen = false;
 	}
@@ -90,7 +99,9 @@
 						<span class="icon-[lucide--folders] size-4 text-muted-foreground"></span>
 						<div class="flex flex-col">
 							<span>Folder View</span>
-							<span class="text-muted-foreground text-[11px] font-normal">Group by resource type</span>
+							<span class="text-muted-foreground text-[11px] font-normal"
+								>Group by resource type</span
+							>
 						</div>
 					</div>
 				</Select.Item>
@@ -101,11 +112,57 @@
 			variant="outline"
 			size="icon"
 			class="size-8 shrink-0 bg-background shadow-xs"
+			onclick={onExpandAll}
+			aria-label="Expand all"
+			title="Expand all"
+		>
+			<span class="icon-[lucide--unfold-vertical] size-4"></span>
+		</Button>
+
+		<Button
+			variant="outline"
+			size="icon"
+			class="size-8 shrink-0 bg-background shadow-xs"
+			onclick={onCollapseAll}
+			aria-label="Collapse all"
+			title="Collapse all"
+		>
+			<span class="icon-[lucide--fold-vertical] size-4"></span>
+		</Button>
+
+		<Button
+			variant="outline"
+			size="icon"
+			class="size-8 shrink-0 bg-background shadow-xs"
 			onclick={openSettings}
 			aria-label="Tree settings"
+			title="Tree settings"
 		>
 			<span class="icon-[mdi--cog-outline] size-4"></span>
 		</Button>
+	</div>
+
+	<div class="relative mt-1.5">
+		<span
+			class="icon-[lucide--search] text-muted-foreground pointer-events-none absolute left-2 top-1/2 size-3.5 -translate-y-1/2"
+		></span>
+		<Input
+			value={searchQuery}
+			oninput={(e) => onSearchChange(e.currentTarget.value)}
+			placeholder="Filter resources..."
+			class="h-7 bg-background pl-7 pr-7 text-xs shadow-xs"
+			aria-label="Filter resources"
+		/>
+		{#if searchQuery}
+			<button
+				type="button"
+				class="text-muted-foreground hover:text-foreground absolute right-1.5 top-1/2 flex size-4 -translate-y-1/2 items-center justify-center"
+				onclick={() => onSearchChange('')}
+				aria-label="Clear filter"
+			>
+				<span class="icon-[lucide--x] size-3.5"></span>
+			</button>
+		{/if}
 	</div>
 </div>
 
@@ -144,22 +201,43 @@
 				</Select.Root>
 			</div>
 
+			<div class="grid items-center gap-2 sm:grid-cols-[1fr_180px] sm:gap-4">
+				<div class="space-y-0.5">
+					<Label for="resource-tree-density">Row density</Label>
+					<p class="text-muted-foreground text-xs">Compact fits more rows per screen.</p>
+				</div>
+				<Select.Root type="single" bind:value={draftDensity}>
+					<Select.Trigger id="resource-tree-density" size="sm" class="h-8 w-full">
+						{draftDensity === 'compact' ? 'Compact' : 'Comfortable'}
+					</Select.Trigger>
+					<Select.Content>
+						<Select.Item value="comfortable" label="Comfortable">Comfortable</Select.Item>
+						<Select.Item value="compact" label="Compact">Compact</Select.Item>
+					</Select.Content>
+				</Select.Root>
+			</div>
+
 			<div class="space-y-2">
-				<div class="hover:bg-muted/40 flex items-start gap-3 rounded-lg border p-3 transition-colors">
+				<div
+					class="hover:bg-muted/40 flex items-start gap-3 rounded-lg border p-3 transition-colors"
+				>
 					<Checkbox
 						id="resource-tree-group-templates"
 						class="mt-0.5"
 						bind:checked={draftGroupTemplates}
 					/>
 					<div class="min-w-0 space-y-1">
-						<Label for="resource-tree-group-templates" class="cursor-pointer">Group templates</Label>
+						<Label for="resource-tree-group-templates" class="cursor-pointer">Group templates</Label
+						>
 						<p class="text-muted-foreground text-xs leading-relaxed">
 							Keep VM and jail templates in a dedicated Templates branch.
 						</p>
 					</div>
 				</div>
 
-				<div class="hover:bg-muted/40 flex items-start gap-3 rounded-lg border p-3 transition-colors">
+				<div
+					class="hover:bg-muted/40 flex items-start gap-3 rounded-lg border p-3 transition-colors"
+				>
 					<Checkbox
 						id="resource-tree-group-guests"
 						class="mt-0.5"

--- a/web/src/lib/components/skeleton/Shell.svelte
+++ b/web/src/lib/components/skeleton/Shell.svelte
@@ -50,9 +50,21 @@
 		'sylve-resource-tree-preferences-v1',
 		DEFAULT_RESOURCE_TREE_PREFERENCES
 	);
-	let treePreferences = $derived(
-		normalizeResourceTreePreferences(resourceTreePreferences.current)
-	);
+	let treePreferences = $derived(normalizeResourceTreePreferences(resourceTreePreferences.current));
+
+	let treeSearchQuery = $state('');
+	let leftPanelRef = $state<{ expandAll: () => void; collapseAll: () => void } | undefined>();
+	let leftPanelClusteredRef = $state<
+		{ expandAll: () => void; collapseAll: () => void } | undefined
+	>();
+
+	function expandTree() {
+		(clustered ? leftPanelClusteredRef : leftPanelRef)?.expandAll();
+	}
+
+	function collapseTree() {
+		(clustered ? leftPanelClusteredRef : leftPanelRef)?.collapseAll();
+	}
 
 	let leftPaneDefaultSize = $state(12);
 	let topPaneDefaultSize = $state(90);
@@ -90,12 +102,24 @@
 								<ResourceTreeToolbar
 									preferences={treePreferences}
 									onChange={updateTreePreferences}
+									searchQuery={treeSearchQuery}
+									onSearchChange={(value) => (treeSearchQuery = value)}
+									onExpandAll={expandTree}
+									onCollapseAll={collapseTree}
 								/>
 								<div class="min-h-0 flex-1" transition:fade|global={{ duration: 400 }}>
 									{#if clustered}
-										<LeftPanelClustered preferences={treePreferences} />
+										<LeftPanelClustered
+											bind:this={leftPanelClusteredRef}
+											preferences={treePreferences}
+											searchQuery={treeSearchQuery}
+										/>
 									{:else}
-										<LeftPanel preferences={treePreferences} />
+										<LeftPanel
+											bind:this={leftPanelRef}
+											preferences={treePreferences}
+											searchQuery={treeSearchQuery}
+										/>
 									{/if}
 								</div>
 							</div>

--- a/web/src/lib/components/skeleton/TreeViewCluster.svelte
+++ b/web/src/lib/components/skeleton/TreeViewCluster.svelte
@@ -22,7 +22,11 @@
 	import CustomValueInput from '$lib/components/ui/custom-input/value.svelte';
 	import { handleAPIError, isAPIResponse } from '$lib/utils/http';
 	import { useSafeGoto } from '$lib/hooks/navigation.svelte';
-	import type { ResourceTreeItem } from '$lib/resource-tree';
+	import {
+		isResourceTreeGroup,
+		type ResourceTreeDensity,
+		type ResourceTreeItem
+	} from '$lib/resource-tree';
 	import { removeStaleCacheByRID } from '$lib/utils/vm/vm';
 
 	interface Props {
@@ -32,6 +36,7 @@
 		nextGuestId?: number;
 		canMigrate?: boolean;
 		onMigrate?: (item: ResourceTreeItem) => void;
+		density?: ResourceTreeDensity;
 	}
 
 	let {
@@ -40,9 +45,16 @@
 		onToggleId,
 		nextGuestId = 100,
 		canMigrate = false,
-		onMigrate
+		onMigrate,
+		density = 'comfortable'
 	}: Props = $props();
 	let isOpen = $derived(openIds.has(item.id));
+	let isGroup = $derived(isResourceTreeGroup(item));
+	let isOfflineNode = $derived(item.icon === 'mdi--server-off');
+	let isCompact = $derived(density === 'compact');
+	let rowPaddingClass = $derived(isCompact ? 'py-0' : 'py-0.5');
+	let rowSpacingClass = $derived(isCompact ? 'my-0' : 'my-0.5');
+	let iconSizePx = $derived(isCompact ? 16 : 18);
 
 	const handleLabelClick = (e: MouseEvent) => {
 		e.preventDefault();
@@ -59,7 +71,26 @@
 		}
 	};
 
-	const sidebarActive = 'rounded-md bg-muted dark:bg-muted font-inter font-medium';
+	const handleGroupClick = (e: MouseEvent) => {
+		e.preventDefault();
+		onToggleId(item.id);
+	};
+
+	function statusDotClass(state?: 'active' | 'inactive' | 'orphan'): string | null {
+		if (state === 'active') return 'bg-green-500';
+		if (state === 'orphan') return 'bg-amber-500';
+		if (state === 'inactive') return 'bg-muted-foreground/50';
+		return null;
+	}
+
+	const handleQuickAction = async (e: MouseEvent) => {
+		e.preventDefault();
+		e.stopPropagation();
+		await handleActionClick(item.state === 'active' ? 'stop' : 'start');
+	};
+
+	const sidebarActive =
+		'rounded-md bg-primary/10 dark:bg-primary/15 border-l-2 border-primary font-inter font-medium';
 
 	function isItemActive(menuItem: ResourceTreeItem, currentUrl: string): boolean {
 		if (menuItem.href) {
@@ -84,6 +115,11 @@
 			item.resourceType === 'jail' ||
 			item.resourceType === 'jail-template' ||
 			item.resourceType === 'vm-template'
+	);
+	let showQuickAction = $derived(
+		(item.resourceType === 'vm' || item.resourceType === 'jail') &&
+			item.resourceId !== undefined &&
+			(item.state === 'active' || item.state === 'inactive')
 	);
 	let lastActiveUrl = $derived.by(() => {
 		const segments = activeUrl.split('/');
@@ -325,34 +361,55 @@
 </script>
 
 <li class="w-full">
-	{#if hasContextMenu}
+	{#if isGroup}
+		<div
+			role="button"
+			tabindex="0"
+			class={`${rowSpacingClass} text-muted-foreground hover:bg-muted/40 dark:hover:bg-muted/40 flex w-full cursor-pointer items-center justify-between rounded-md px-1.5 ${rowPaddingClass}`}
+			onclick={handleGroupClick}
+			onkeydown={(e) => (e.key === 'Enter' || e.key === ' ' ? handleGroupClick(e as any) : null)}
+		>
+			<div class="flex min-w-0 items-center gap-1.5">
+				<span class={`icon-[${item.icon}] size-3.5 shrink-0`}></span>
+				<span class="truncate text-[11px] font-semibold tracking-wide uppercase">{item.label}</span>
+				<span class="text-muted-foreground/70 text-[10px] font-normal">{item.children?.length}</span
+				>
+			</div>
+			<span class={`icon-[teenyicons--${isOpen ? 'down-solid' : 'right-solid'}] h-3 w-3 shrink-0`}
+			></span>
+		</div>
+	{:else if hasContextMenu}
 		<ContextMenu.Root>
 			<ContextMenu.Trigger
 				role="button"
 				tabindex={0}
-				class={`my-0.5 flex w-full cursor-pointer items-center justify-between px-1.5 py-0.5 ${isActive ? sidebarActive : 'hover:bg-muted dark:hover:bg-muted rounded-md'}${lastActiveUrl === item.label ? 'text-primary!' : ' '}`}
+				class={`group ${rowSpacingClass} flex w-full cursor-pointer items-center justify-between px-1.5 ${rowPaddingClass} ${isActive ? sidebarActive : 'hover:bg-muted dark:hover:bg-muted rounded-md'}${lastActiveUrl === item.label ? 'text-primary!' : ' '}`}
 				onclick={handleLabelClick}
 				onkeydown={(e) => (e.key === 'Enter' || e.key === ' ' ? handleLabelClick(e as any) : null)}
 			>
-				<div class="flex items-center space-x-1 text-sm">
+				<div class="flex min-w-0 items-center space-x-1 text-sm">
 					{#if item.icon === 'material-symbols--monitor-outline' || item.icon === 'hugeicons--prison'}
 						<div class="flex items-center space-x-1 text-sm">
 							<div class="relative">
-								<span class={`icon-[${item.icon}]`} style="width: 18px; height: 18px;"></span>
-								{#if item.state && item.state === 'active'}
+								<span
+									class={`icon-[${item.icon}]`}
+									style={`width: ${iconSizePx}px; height: ${iconSizePx}px;`}
+								></span>
+								{#if statusDotClass(item.state)}
 									<div
-										class="absolute -right-1 bottom-0.5 flex h-2 w-2 items-center justify-center rounded-full bg-green-500"
-									>
-										<span class="icon-[mdi--play] h-2 w-2 text-white"></span>
-									</div>
+										class={`absolute -right-1 bottom-0.5 h-2 w-2 rounded-full ring-2 ring-background ${statusDotClass(item.state)}`}
+									></div>
 								{/if}
 							</div>
 						</div>
 					{:else}
-						<span class={`icon-[${item.icon}]`} style="width: 18px; height: 18px;"></span>
+						<span
+							class={`icon-[${item.icon}]`}
+							style={`width: ${iconSizePx}px; height: ${iconSizePx}px;`}
+						></span>
 					{/if}
 					<p
-						class="font-inter cursor-pointer whitespace-nowrap"
+						class="font-inter cursor-pointer truncate whitespace-nowrap"
 						title={item.meta ? `${item.label} · ${item.meta}` : item.label}
 					>
 						{item.label}
@@ -363,16 +420,29 @@
 					</p>
 				</div>
 
-				{#if item.children && item.children.length > 0}
-					<span
-						role="button"
-						tabindex="0"
-						class={`icon-[teenyicons--${isOpen ? 'down-solid' : 'right-solid'}] h-3.5 w-3.5 cursor-pointer`}
-						onclick={handleIconClick}
-						onkeydown={(e) =>
-							e.key === 'Enter' || e.key === ' ' ? handleIconClick(e as any) : null}
-					></span>
-				{/if}
+				<div class="flex shrink-0 items-center gap-0.5">
+					{#if showQuickAction}
+						<button
+							type="button"
+							class="hover:bg-background hidden size-5 items-center justify-center rounded group-hover:flex"
+							title={item.state === 'active' ? 'Stop' : 'Start'}
+							onclick={(e) => void handleQuickAction(e)}
+						>
+							<span class={`icon-[mdi--${item.state === 'active' ? 'stop' : 'play'}] h-3.5 w-3.5`}
+							></span>
+						</button>
+					{/if}
+					{#if item.children && item.children.length > 0}
+						<span
+							role="button"
+							tabindex="0"
+							class={`icon-[teenyicons--${isOpen ? 'down-solid' : 'right-solid'}] h-3.5 w-3.5 cursor-pointer`}
+							onclick={handleIconClick}
+							onkeydown={(e) =>
+								e.key === 'Enter' || e.key === ' ' ? handleIconClick(e as any) : null}
+						></span>
+					{/if}
+				</div>
 			</ContextMenu.Trigger>
 			<ContextMenu.Content>
 				{#if item.resourceType === 'jail'}
@@ -508,29 +578,33 @@
 		<div
 			role="button"
 			tabindex="0"
-			class={`my-0.5 flex w-full cursor-pointer items-center justify-between px-1.5 py-0.5 ${isActive ? sidebarActive : 'hover:bg-muted dark:hover:bg-muted rounded-md'}${lastActiveUrl === item.label ? 'text-primary!' : ' '}`}
+			class={`${rowSpacingClass} flex w-full cursor-pointer items-center justify-between px-1.5 ${rowPaddingClass} ${isActive ? sidebarActive : 'hover:bg-muted dark:hover:bg-muted rounded-md'}${lastActiveUrl === item.label ? 'text-primary!' : ' '}${isOfflineNode ? ' opacity-60' : ''}`}
 			onclick={handleLabelClick}
 			onkeydown={(e) => (e.key === 'Enter' || e.key === ' ' ? handleLabelClick(e as any) : null)}
 		>
-			<div class="flex items-center space-x-1 text-sm">
+			<div class="flex min-w-0 items-center space-x-1 text-sm">
 				{#if item.icon === 'material-symbols--monitor-outline' || item.icon === 'hugeicons--prison'}
 					<div class="flex items-center space-x-1 text-sm">
 						<div class="relative">
-							<span class={`icon-[${item.icon}]`} style="width: 18px; height: 18px;"></span>
-							{#if item.state && item.state === 'active'}
+							<span
+								class={`icon-[${item.icon}]`}
+								style={`width: ${iconSizePx}px; height: ${iconSizePx}px;`}
+							></span>
+							{#if statusDotClass(item.state)}
 								<div
-									class="absolute -right-1 bottom-0.5 flex h-2 w-2 items-center justify-center rounded-full bg-green-500"
-								>
-									<span class="icon-[mdi--play] h-2 w-2 text-white"></span>
-								</div>
+									class={`absolute -right-1 bottom-0.5 h-2 w-2 rounded-full ring-2 ring-background ${statusDotClass(item.state)}`}
+								></div>
 							{/if}
 						</div>
 					</div>
 				{:else}
-					<span class={`icon-[${item.icon}]`} style="width: 18px; height: 18px;"></span>
+					<span
+						class={`icon-[${item.icon}]`}
+						style={`width: ${iconSizePx}px; height: ${iconSizePx}px;`}
+					></span>
 				{/if}
 				<p
-					class="font-inter cursor-pointer whitespace-nowrap"
+					class="font-inter cursor-pointer truncate whitespace-nowrap"
 					title={item.meta ? `${item.label} · ${item.meta}` : item.label}
 				>
 					{item.label}
@@ -538,13 +612,19 @@
 						<span class="text-muted-foreground ml-1.5 text-[11px] font-normal">· {item.meta}</span>
 					{/if}
 				</p>
+				{#if isOfflineNode}
+					<span
+						class="bg-muted text-muted-foreground shrink-0 rounded px-1 py-0.5 text-[10px] font-medium"
+						>Offline</span
+					>
+				{/if}
 			</div>
 
 			{#if item.children && item.children.length > 0}
 				<span
 					role="button"
 					tabindex="0"
-					class={`icon-[teenyicons--${isOpen ? 'down-solid' : 'right-solid'}] h-3.5 w-3.5 cursor-pointer`}
+					class={`icon-[teenyicons--${isOpen ? 'down-solid' : 'right-solid'}] h-3.5 w-3.5 cursor-pointer shrink-0`}
 					onclick={handleIconClick}
 					onkeydown={(e) => (e.key === 'Enter' || e.key === ' ' ? handleIconClick(e as any) : null)}
 				></span>
@@ -563,6 +643,7 @@
 				nextGuestId={item.nextGuestId ?? nextGuestId}
 				{canMigrate}
 				{onMigrate}
+				{density}
 			/>
 		{/each}
 	</ul>

--- a/web/src/lib/components/skeleton/TreeViewCluster.svelte
+++ b/web/src/lib/components/skeleton/TreeViewCluster.svelte
@@ -83,10 +83,15 @@
 		return null;
 	}
 
+	let quickAction = $derived.by((): 'start' | 'shutdown' | 'stop' => {
+		if (item.state !== 'active') return 'start';
+		return item.resourceType === 'vm' ? 'shutdown' : 'stop';
+	});
+
 	const handleQuickAction = async (e: MouseEvent) => {
 		e.preventDefault();
 		e.stopPropagation();
-		await handleActionClick(item.state === 'active' ? 'stop' : 'start');
+		await handleActionClick(quickAction);
 	};
 
 	const sidebarActive =
@@ -425,10 +430,15 @@
 						<button
 							type="button"
 							class="hover:bg-background hidden size-5 items-center justify-center rounded group-hover:flex"
-							title={item.state === 'active' ? 'Stop' : 'Start'}
+							title={quickAction === 'shutdown'
+								? 'Shutdown'
+								: quickAction === 'stop'
+									? 'Stop'
+									: 'Start'}
 							onclick={(e) => void handleQuickAction(e)}
 						>
-							<span class={`icon-[mdi--${item.state === 'active' ? 'stop' : 'play'}] h-3.5 w-3.5`}
+							<span
+								class={`icon-[mdi--${quickAction === 'shutdown' ? 'power' : quickAction === 'stop' ? 'stop' : 'play'}] h-3.5 w-3.5`}
 							></span>
 						</button>
 					{/if}

--- a/web/src/lib/resource-tree.ts
+++ b/web/src/lib/resource-tree.ts
@@ -12,19 +12,22 @@ export type ResourceTreeView = 'server' | 'folder';
 export type ResourceTreeSortKey = 'id' | 'name';
 export type ResourceTreeState = 'active' | 'inactive' | 'orphan';
 export type ResourceTreeResourceType = 'vm' | 'jail' | 'jail-template' | 'vm-template';
+export type ResourceTreeDensity = 'comfortable' | 'compact';
 
 export interface ResourceTreePreferences {
 	view: ResourceTreeView;
 	sortKey: ResourceTreeSortKey;
 	groupTemplates: boolean;
 	groupGuestTypes: boolean;
+	density: ResourceTreeDensity;
 }
 
 export const DEFAULT_RESOURCE_TREE_PREFERENCES: ResourceTreePreferences = {
 	view: 'server',
 	sortKey: 'id',
 	groupTemplates: true,
-	groupGuestTypes: false
+	groupGuestTypes: false,
+	density: 'comfortable'
 };
 
 export interface ResourceTreeItem {
@@ -92,8 +95,43 @@ export function normalizeResourceTreePreferences(value: unknown): ResourceTreePr
 		groupGuestTypes:
 			typeof candidate.groupGuestTypes === 'boolean'
 				? candidate.groupGuestTypes
-				: DEFAULT_RESOURCE_TREE_PREFERENCES.groupGuestTypes
+				: DEFAULT_RESOURCE_TREE_PREFERENCES.groupGuestTypes,
+		density: candidate.density === 'compact' ? 'compact' : 'comfortable'
 	};
+}
+
+export function isResourceTreeGroup(item: ResourceTreeItem): boolean {
+	return !item.resourceType && !item.href && !!item.children;
+}
+
+export function filterResourceTree(items: ResourceTreeItem[], query: string): ResourceTreeItem[] {
+	const q = query.trim().toLowerCase();
+	if (!q) return items;
+
+	function walk(item: ResourceTreeItem): ResourceTreeItem | null {
+		const selfMatch =
+			item.label.toLowerCase().includes(q) || (item.meta?.toLowerCase().includes(q) ?? false);
+
+		if (selfMatch) {
+			return item;
+		}
+
+		if (!item.children) {
+			return null;
+		}
+
+		const filteredChildren = item.children
+			.map(walk)
+			.filter((child): child is ResourceTreeItem => child !== null);
+
+		if (filteredChildren.length === 0) {
+			return null;
+		}
+
+		return { ...item, children: filteredChildren };
+	}
+
+	return items.map(walk).filter((item): item is ResourceTreeItem => item !== null);
 }
 
 export function collectResourceTreeIds(nodes: ResourceTreeItem[]): string[] {

--- a/web/src/locales/cs.po
+++ b/web/src/locales/cs.po
@@ -583,6 +583,7 @@ msgstr "Stav"
 #: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/lib/components/skeleton/TreeViewCluster.svelte
+#: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/lib/components/ui/custom-input/combobox-bindable.svelte
 #: src/lib/components/ui/custom-input/combobox.svelte
 #: src/lib/components/ui/custom-input/combobox.svelte
@@ -2121,6 +2122,7 @@ msgid "Error starting jail"
 msgstr ""
 
 #: src/lib/components/custom/Jail/Template/View.svelte
+#: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/routes/[node]/jail/[ctid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/summary/+page.svelte
@@ -2128,6 +2130,7 @@ msgid "Stop"
 msgstr "Zastavit"
 
 #: src/lib/components/custom/Jail/Template/View.svelte
+#: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/routes/[node]/jail/[ctid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/summary/+page.svelte
@@ -2770,6 +2773,7 @@ msgstr "Spuštěné"
 msgid "Reboot"
 msgstr "Restartovat"
 
+#: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/routes/[node]/vm/[rid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/summary/+page.svelte
 msgid "Shutdown"
@@ -15233,6 +15237,7 @@ msgid "Group by resource type"
 msgstr ""
 
 #: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
 msgid "Tree settings"
 msgstr ""
 
@@ -17071,4 +17076,57 @@ msgstr ""
 
 #: src/lib/components/custom/ZFS/datasets/snapshots/Retention.svelte
 msgid "Snapshot job is unavailable"
+msgstr ""
+
+#. 0: searchQuery
+#. 0: searchQuery
+#: src/lib/components/skeleton/LeftPanel.svelte
+#: src/lib/components/skeleton/LeftPanelClustered.svelte
+msgid "No matches for “{0}”"
+msgstr ""
+
+#: src/lib/components/skeleton/TreeViewCluster.svelte
+msgid "Offline"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Expand all"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Collapse all"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Filter resources..."
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Filter resources"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Clear filter"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Row density"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Compact fits more rows per screen."
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Compact"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Comfortable"
 msgstr ""

--- a/web/src/locales/de.po
+++ b/web/src/locales/de.po
@@ -583,6 +583,7 @@ msgstr "Status"
 #: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/lib/components/skeleton/TreeViewCluster.svelte
+#: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/lib/components/ui/custom-input/combobox-bindable.svelte
 #: src/lib/components/ui/custom-input/combobox.svelte
 #: src/lib/components/ui/custom-input/combobox.svelte
@@ -2121,6 +2122,7 @@ msgid "Error starting jail"
 msgstr "Fehler beim Starten der Jail"
 
 #: src/lib/components/custom/Jail/Template/View.svelte
+#: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/routes/[node]/jail/[ctid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/summary/+page.svelte
@@ -2128,6 +2130,7 @@ msgid "Stop"
 msgstr "Stopp"
 
 #: src/lib/components/custom/Jail/Template/View.svelte
+#: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/routes/[node]/jail/[ctid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/summary/+page.svelte
@@ -2770,6 +2773,7 @@ msgstr "Läuft"
 msgid "Reboot"
 msgstr "Neustart"
 
+#: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/routes/[node]/vm/[rid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/summary/+page.svelte
 msgid "Shutdown"
@@ -15230,6 +15234,7 @@ msgid "Group by resource type"
 msgstr ""
 
 #: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
 msgid "Tree settings"
 msgstr ""
 
@@ -17068,4 +17073,57 @@ msgstr ""
 
 #: src/lib/components/custom/ZFS/datasets/snapshots/Retention.svelte
 msgid "Snapshot job is unavailable"
+msgstr ""
+
+#. 0: searchQuery
+#. 0: searchQuery
+#: src/lib/components/skeleton/LeftPanel.svelte
+#: src/lib/components/skeleton/LeftPanelClustered.svelte
+msgid "No matches for “{0}”"
+msgstr ""
+
+#: src/lib/components/skeleton/TreeViewCluster.svelte
+msgid "Offline"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Expand all"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Collapse all"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Filter resources..."
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Filter resources"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Clear filter"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Row density"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Compact fits more rows per screen."
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Compact"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Comfortable"
 msgstr ""

--- a/web/src/locales/en.po
+++ b/web/src/locales/en.po
@@ -583,6 +583,7 @@ msgstr "Status"
 #: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/lib/components/skeleton/TreeViewCluster.svelte
+#: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/lib/components/ui/custom-input/combobox-bindable.svelte
 #: src/lib/components/ui/custom-input/combobox.svelte
 #: src/lib/components/ui/custom-input/combobox.svelte
@@ -2121,6 +2122,7 @@ msgid "Error starting jail"
 msgstr "Error starting jail"
 
 #: src/lib/components/custom/Jail/Template/View.svelte
+#: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/routes/[node]/jail/[ctid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/summary/+page.svelte
@@ -2128,6 +2130,7 @@ msgid "Stop"
 msgstr "Stop"
 
 #: src/lib/components/custom/Jail/Template/View.svelte
+#: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/routes/[node]/jail/[ctid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/summary/+page.svelte
@@ -2770,6 +2773,7 @@ msgstr "Running"
 msgid "Reboot"
 msgstr "Reboot"
 
+#: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/routes/[node]/vm/[rid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/summary/+page.svelte
 msgid "Shutdown"
@@ -15230,6 +15234,7 @@ msgid "Group by resource type"
 msgstr "Group by resource type"
 
 #: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
 msgid "Tree settings"
 msgstr "Tree settings"
 
@@ -17069,3 +17074,56 @@ msgstr "Copy portal address {0}:{1}"
 #: src/lib/components/custom/ZFS/datasets/snapshots/Retention.svelte
 msgid "Snapshot job is unavailable"
 msgstr "Snapshot job is unavailable"
+
+#. 0: searchQuery
+#. 0: searchQuery
+#: src/lib/components/skeleton/LeftPanel.svelte
+#: src/lib/components/skeleton/LeftPanelClustered.svelte
+msgid "No matches for “{0}”"
+msgstr "No matches for “{0}”"
+
+#: src/lib/components/skeleton/TreeViewCluster.svelte
+msgid "Offline"
+msgstr "Offline"
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Expand all"
+msgstr "Expand all"
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Collapse all"
+msgstr "Collapse all"
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Filter resources..."
+msgstr "Filter resources..."
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Filter resources"
+msgstr "Filter resources"
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Clear filter"
+msgstr "Clear filter"
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Row density"
+msgstr "Row density"
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Compact fits more rows per screen."
+msgstr "Compact fits more rows per screen."
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Compact"
+msgstr "Compact"
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Comfortable"
+msgstr "Comfortable"

--- a/web/src/locales/hi.po
+++ b/web/src/locales/hi.po
@@ -583,6 +583,7 @@ msgstr "स्थिति"
 #: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/lib/components/skeleton/TreeViewCluster.svelte
+#: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/lib/components/ui/custom-input/combobox-bindable.svelte
 #: src/lib/components/ui/custom-input/combobox.svelte
 #: src/lib/components/ui/custom-input/combobox.svelte
@@ -2121,6 +2122,7 @@ msgid "Error starting jail"
 msgstr "जेल शुरू करने में त्रुटि"
 
 #: src/lib/components/custom/Jail/Template/View.svelte
+#: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/routes/[node]/jail/[ctid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/summary/+page.svelte
@@ -2128,6 +2130,7 @@ msgid "Stop"
 msgstr "रोकें"
 
 #: src/lib/components/custom/Jail/Template/View.svelte
+#: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/routes/[node]/jail/[ctid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/summary/+page.svelte
@@ -2770,6 +2773,7 @@ msgstr "चल रहा है"
 msgid "Reboot"
 msgstr "रीबूट"
 
+#: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/routes/[node]/vm/[rid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/summary/+page.svelte
 msgid "Shutdown"
@@ -15230,6 +15234,7 @@ msgid "Group by resource type"
 msgstr ""
 
 #: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
 msgid "Tree settings"
 msgstr ""
 
@@ -17068,4 +17073,57 @@ msgstr ""
 
 #: src/lib/components/custom/ZFS/datasets/snapshots/Retention.svelte
 msgid "Snapshot job is unavailable"
+msgstr ""
+
+#. 0: searchQuery
+#. 0: searchQuery
+#: src/lib/components/skeleton/LeftPanel.svelte
+#: src/lib/components/skeleton/LeftPanelClustered.svelte
+msgid "No matches for “{0}”"
+msgstr ""
+
+#: src/lib/components/skeleton/TreeViewCluster.svelte
+msgid "Offline"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Expand all"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Collapse all"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Filter resources..."
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Filter resources"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Clear filter"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Row density"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Compact fits more rows per screen."
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Compact"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Comfortable"
 msgstr ""

--- a/web/src/locales/mal.po
+++ b/web/src/locales/mal.po
@@ -583,6 +583,7 @@ msgstr "സ്റ്റാറ്റസ്"
 #: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/lib/components/skeleton/TreeViewCluster.svelte
+#: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/lib/components/ui/custom-input/combobox-bindable.svelte
 #: src/lib/components/ui/custom-input/combobox.svelte
 #: src/lib/components/ui/custom-input/combobox.svelte
@@ -2121,6 +2122,7 @@ msgid "Error starting jail"
 msgstr "Jail ആരംഭിക്കുന്നതിൽ പിശക്"
 
 #: src/lib/components/custom/Jail/Template/View.svelte
+#: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/routes/[node]/jail/[ctid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/summary/+page.svelte
@@ -2128,6 +2130,7 @@ msgid "Stop"
 msgstr "നിർത്തുക"
 
 #: src/lib/components/custom/Jail/Template/View.svelte
+#: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/routes/[node]/jail/[ctid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/summary/+page.svelte
@@ -2770,6 +2773,7 @@ msgstr "പ്രവർത്തിക്കുന്നു"
 msgid "Reboot"
 msgstr "റീബൂട്ട് ചെയ്യുക"
 
+#: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/routes/[node]/vm/[rid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/summary/+page.svelte
 msgid "Shutdown"
@@ -15230,6 +15234,7 @@ msgid "Group by resource type"
 msgstr ""
 
 #: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
 msgid "Tree settings"
 msgstr ""
 
@@ -17068,4 +17073,57 @@ msgstr ""
 
 #: src/lib/components/custom/ZFS/datasets/snapshots/Retention.svelte
 msgid "Snapshot job is unavailable"
+msgstr ""
+
+#. 0: searchQuery
+#. 0: searchQuery
+#: src/lib/components/skeleton/LeftPanel.svelte
+#: src/lib/components/skeleton/LeftPanelClustered.svelte
+msgid "No matches for “{0}”"
+msgstr ""
+
+#: src/lib/components/skeleton/TreeViewCluster.svelte
+msgid "Offline"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Expand all"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Collapse all"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Filter resources..."
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Filter resources"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Clear filter"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Row density"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Compact fits more rows per screen."
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Compact"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Comfortable"
 msgstr ""

--- a/web/src/locales/zh-CN.po
+++ b/web/src/locales/zh-CN.po
@@ -583,6 +583,7 @@ msgstr "状态"
 #: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/lib/components/skeleton/TreeViewCluster.svelte
+#: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/lib/components/ui/custom-input/combobox-bindable.svelte
 #: src/lib/components/ui/custom-input/combobox.svelte
 #: src/lib/components/ui/custom-input/combobox.svelte
@@ -2121,6 +2122,7 @@ msgid "Error starting jail"
 msgstr "启动 Jail 时出错"
 
 #: src/lib/components/custom/Jail/Template/View.svelte
+#: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/routes/[node]/jail/[ctid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/summary/+page.svelte
@@ -2128,6 +2130,7 @@ msgid "Stop"
 msgstr "停止"
 
 #: src/lib/components/custom/Jail/Template/View.svelte
+#: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/routes/[node]/jail/[ctid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/summary/+page.svelte
@@ -2770,6 +2773,7 @@ msgstr "正在运行"
 msgid "Reboot"
 msgstr "重启"
 
+#: src/lib/components/skeleton/TreeViewCluster.svelte
 #: src/routes/[node]/vm/[rid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/summary/+page.svelte
 msgid "Shutdown"
@@ -15227,6 +15231,7 @@ msgid "Group by resource type"
 msgstr ""
 
 #: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
 msgid "Tree settings"
 msgstr ""
 
@@ -17065,4 +17070,57 @@ msgstr ""
 
 #: src/lib/components/custom/ZFS/datasets/snapshots/Retention.svelte
 msgid "Snapshot job is unavailable"
+msgstr ""
+
+#. 0: searchQuery
+#. 0: searchQuery
+#: src/lib/components/skeleton/LeftPanel.svelte
+#: src/lib/components/skeleton/LeftPanelClustered.svelte
+msgid "No matches for “{0}”"
+msgstr ""
+
+#: src/lib/components/skeleton/TreeViewCluster.svelte
+msgid "Offline"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Expand all"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Collapse all"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Filter resources..."
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Filter resources"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Clear filter"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Row density"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Compact fits more rows per screen."
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Compact"
+msgstr ""
+
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+#: src/lib/components/skeleton/ResourceTreeToolbar.svelte
+msgid "Comfortable"
 msgstr ""


### PR DESCRIPTION
- Add a search box to the sidebar toolbar that filters the tree by name and auto-expands matching branches
- Add expand-all/collapse-all buttons next to the view selector
- Add a row density option (comfortable/compact) next to the existing sort/group settings
- Give stopped and orphaned guests their own status dot color instead of only marking running ones
- Show a start/stop button on hover for VM/jail rows so the common action doesn't need a right-click
- Group headers (Virtual Machines/Jails/Templates) now show a count and the whole row toggles, not just the chevron
- Mark offline cluster nodes with reduced opacity and a badge instead of leaving them looking fully interactive
- Give the selected row a left accent border so it's distinguishable from hover, which used to share the same background