### PR TITLE
system: self-restart in place on setup instead of rebooting the host when jailed.

### DIFF
--- a/internal/handlers/health.go
+++ b/internal/handlers/health.go
@@ -61,6 +61,7 @@ func BasicHealthCheckHandler(systemService *system.Service) gin.HandlerFunc {
 				"hostname":     h,
 				"initialized":  b.Initialized,
 				"restarted":    b.Restarted,
+				"jailed":       systemService.IsJailed(),
 				"sylveVersion": cmd.Version,
 			},
 		})

--- a/internal/services/system/core.go
+++ b/internal/services/system/core.go
@@ -8,9 +8,72 @@
 
 package system
 
-import "github.com/alchemillahq/sylve/pkg/utils"
+import (
+	"os"
+	"syscall"
+	"time"
+
+	"github.com/alchemillahq/sylve/internal/db/models"
+	"github.com/alchemillahq/sylve/pkg/utils"
+	"github.com/alchemillahq/sylve/pkg/utils/sysctl"
+)
+
+// Seams so the jailed self-restart path is testable: override the jail check
+// and capture the re-exec instead of replacing the test process image.
+var (
+	rebootSysctlGetInt64 = sysctl.GetInt64
+	rebootReexec         = reexecSelf
+)
+
+// reexecSelf restarts Sylve in place by replacing the current process image
+// with a fresh copy of the same binary (same PID). This restarts the process
+// without depending on an external supervisor, so a jailed restart works
+// whether Sylve is run under s6, podman --restart, daemon(8), or standalone.
+// If exec fails, it exits instead so a supervised environment can still
+// relaunch it.
+func reexecSelf() {
+	if exe, err := os.Executable(); err == nil {
+		syscall.Exec(exe, os.Args, os.Environ())
+	}
+	os.Exit(0)
+}
+
+// IsJailed reports whether this process is running inside a FreeBSD jail.
+// Used to decide between an actual host reboot and a self-restart, and
+// surfaced via /health/basic so the frontend can label the action
+// accordingly ("Restart" vs "Reboot").
+func (s *Service) IsJailed() bool {
+	jailed, err := rebootSysctlGetInt64("security.jail.jailed")
+	return err == nil && jailed == 1
+}
 
 func (s *Service) RebootSystem() error {
+	// A jailed process can never reboot the host -- PRIV_REBOOT is not
+	// grantable to jails (same restriction as PRIV_KLD), so /sbin/shutdown
+	// -r now just fails here. What actually needs to happen is for this
+	// process to restart in place, so shouldStartAdvancedStartupWorkers()
+	// sees Restarted=true on the next boot. We re-exec ourselves rather than
+	// rely on a supervisor, so this works within the SAME jail regardless of
+	// how Sylve was launched -- no host reboot required.
+	if s.IsJailed() {
+		var basicSettings models.BasicSettings
+		if err := s.DB.First(&basicSettings).Error; err != nil {
+			return err
+		}
+		basicSettings.Restarted = true
+		if err := s.DB.Save(&basicSettings).Error; err != nil {
+			return err
+		}
+
+		go func() {
+			// Give the success response time to flush to the client before
+			// we re-exec in place.
+			time.Sleep(500 * time.Millisecond)
+			rebootReexec()
+		}()
+		return nil
+	}
+
 	_, err := utils.RunCommand(
 		"/sbin/shutdown",
 		"-r",

--- a/internal/services/system/core_test.go
+++ b/internal/services/system/core_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Copyright (c) 2025 The FreeBSD Foundation.
+
+package system
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alchemillahq/sylve/internal/db/models"
+	"github.com/alchemillahq/sylve/internal/testutil"
+)
+
+func TestIsJailedReadsSysctl(t *testing.T) {
+	orig := rebootSysctlGetInt64
+	t.Cleanup(func() { rebootSysctlGetInt64 = orig })
+
+	rebootSysctlGetInt64 = func(string) (int64, error) { return 1, nil }
+	if !(&Service{}).IsJailed() {
+		t.Fatal("expected IsJailed()=true when security.jail.jailed=1")
+	}
+
+	rebootSysctlGetInt64 = func(string) (int64, error) { return 0, nil }
+	if (&Service{}).IsJailed() {
+		t.Fatal("expected IsJailed()=false when security.jail.jailed=0")
+	}
+}
+
+// Inside a jail, RebootSystem must not shell out to shutdown; it flips
+// Restarted and re-execs the process in place.
+func TestRebootSystemJailedSelfRestarts(t *testing.T) {
+	origJail, origReexec := rebootSysctlGetInt64, rebootReexec
+	t.Cleanup(func() { rebootSysctlGetInt64 = origJail; rebootReexec = origReexec })
+
+	rebootSysctlGetInt64 = func(string) (int64, error) { return 1, nil } // jailed
+	reexeced := make(chan struct{}, 1)
+	rebootReexec = func() { reexeced <- struct{}{} }
+
+	db := testutil.NewSQLiteTestDB(t, &models.BasicSettings{})
+	if err := db.Create(&models.BasicSettings{Initialized: true, Restarted: false}).Error; err != nil {
+		t.Fatalf("seed BasicSettings: %v", err)
+	}
+	s := &Service{DB: db}
+
+	if err := s.RebootSystem(); err != nil {
+		t.Fatalf("RebootSystem returned error: %v", err)
+	}
+
+	var bs models.BasicSettings
+	if err := db.First(&bs).Error; err != nil {
+		t.Fatalf("load BasicSettings: %v", err)
+	}
+	if !bs.Restarted {
+		t.Fatal("expected Restarted=true after jailed RebootSystem")
+	}
+
+	select {
+	case <-reexeced:
+		// re-exec was invoked as expected
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected self-restart re-exec, none happened")
+	}
+}

--- a/web/src/lib/api/system/system.ts
+++ b/web/src/lib/api/system/system.ts
@@ -7,6 +7,7 @@ export const BasicHealthSchema = z.object({
 	hostname: z.string().optional(),
 	initialized: z.boolean(),
 	restarted: z.boolean(),
+	jailed: z.boolean().optional(),
 	sylveVersion: z.string().optional()
 });
 

--- a/web/src/lib/components/custom/Initialization/Reboot.svelte
+++ b/web/src/lib/components/custom/Initialization/Reboot.svelte
@@ -4,19 +4,54 @@
 	import { mode } from 'mode-watcher';
 	import { probeBasicHealth, rebootSystem } from '$lib/api/system/system';
 	import { handleAPIError } from '$lib/utils/http';
+	import { onMount } from 'svelte';
 
 	let rebootInitiated = $state(false);
+	// In a jail/container, this action can't actually reboot the host --
+	// it restarts the Sylve process instead. Label it accordingly.
+	let jailed = $state(false);
 
-	async function waitForRebootCycle({ intervalMs = 2000, timeoutMs = 60 * 60 * 1000 } = {}) {
-		const start = Date.now();
+	onMount(async () => {
+		const health = await probeBasicHealth();
+		jailed = health?.jailed === true;
+	});
 
-		while (Date.now() - start < timeoutMs) {
+	async function waitForRebootCycle({
+		downIntervalMs = 200,
+		downTimeoutMs = 30 * 1000,
+		upIntervalMs = 1000,
+		upTimeoutMs = 60 * 60 * 1000
+	} = {}) {
+		// The restart flag is persisted before the process actually exits
+		// (see RebootSystem() in core.go), so polling for it alone can hit
+		// the *old*, still-running process and report success before a
+		// restart has actually happened. Require the server to actually go
+		// unreachable first -- proving the old process died -- before
+		// waiting for it to come back. The down-window for a jailed restart
+		// is narrow (~500ms exit delay + ~1s app boot), so poll tightly here
+		// or a slower interval can straddle the whole cycle and miss it.
+		const downStart = Date.now();
+		let wentDown = false;
+		while (Date.now() - downStart < downTimeoutMs) {
+			const health = await probeBasicHealth();
+			if (health === null) {
+				wentDown = true;
+				break;
+			}
+			await new Promise((r) => setTimeout(r, downIntervalMs));
+		}
+		if (!wentDown) {
+			throw new Error('Service did not go down for restart');
+		}
+
+		const upStart = Date.now();
+		while (Date.now() - upStart < upTimeoutMs) {
 			const health = await probeBasicHealth();
 			if (health?.initialized === true && health.restarted === true) {
 				return true;
 			}
 
-			await new Promise((r) => setTimeout(r, intervalMs));
+			await new Promise((r) => setTimeout(r, upIntervalMs));
 		}
 
 		throw new Error('Reboot cycle not completed in time');
@@ -35,9 +70,13 @@
 				return;
 			}
 
-			toast.info('System is restarting...', { position: 'bottom-center' });
+			toast.info(jailed ? 'Sylve is restarting...' : 'System is restarting...', {
+				position: 'bottom-center'
+			});
 			await waitForRebootCycle();
-			toast.success('System is back online', { position: 'bottom-center' });
+			toast.success(jailed ? 'Sylve is back online' : 'System is back online', {
+				position: 'bottom-center'
+			});
 			setTimeout(() => {
 				window.location.href = '/datacenter/summary';
 			}, 1000);
@@ -72,17 +111,22 @@
 		<!-- Content -->
 		<div class="space-y-6">
 			<p class="text-muted-foreground text-sm max-w-xs mx-auto">
-				A <span class="font-medium text-foreground">full system reboot</span> is required for Sylve to
-				finish initialization. Continue when ready.
+				{#if jailed}
+					A <span class="font-medium text-foreground">quick restart</span> is required for Sylve to
+					finish initialization. Continue when ready.
+				{:else}
+					A <span class="font-medium text-foreground">full system reboot</span> is required for Sylve
+					to finish initialization. Continue when ready.
+				{/if}
 			</p>
 
 			<Button onclick={handleReboot} class="px-8 py-2.5" disabled={rebootInitiated}>
 				{#if rebootInitiated}
 					<span class="icon icon-[mdi--loading] w-4 h-4 mr-2 inline-block animate-spin"></span>
-					Rebooting...
+					{jailed ? 'Restarting...' : 'Rebooting...'}
 				{:else}
 					<span class="icon icon-[mdi--restart] w-4 h-4 mr-2 inline-block"></span>
-					Reboot
+					{jailed ? 'Restart' : 'Reboot'}
 				{/if}
 			</Button>
 		</div>

--- a/web/src/locales/cs.po
+++ b/web/src/locales/cs.po
@@ -1970,11 +1970,9 @@ msgstr "Nastavení dokončeno"
 msgid "A <0>full system reboot</0> is required for Sylve to finish initialization. Continue when ready."
 msgstr ""
 
-#: src/lib/components/custom/Initialization/Reboot.svelte
-msgid "<0/> Rebooting..."
-msgstr "<0/> Restartování…"
+#~ msgid "<0/> Rebooting..."
+#~ msgstr "<0/> Restartování…"
 
-#: src/lib/components/custom/Initialization/Reboot.svelte
 #: src/lib/components/skeleton/TreeViewCluster.svelte
 msgid "<0/> Reboot"
 msgstr "<0/> Restartovat"
@@ -2765,6 +2763,7 @@ msgstr ""
 msgid "Running"
 msgstr "Spuštěné"
 
+#: src/lib/components/custom/Initialization/Reboot.svelte
 #: src/routes/[node]/vm/[rid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/summary/+page.svelte
 msgid "Reboot"
@@ -17071,4 +17070,28 @@ msgstr ""
 
 #: src/lib/components/custom/ZFS/datasets/snapshots/Retention.svelte
 msgid "Snapshot job is unavailable"
+msgstr ""
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "Sylve is restarting..."
+msgstr ""
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "Sylve is back online"
+msgstr ""
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "A <0>quick restart</0> is required for Sylve to finish initialization. Continue when ready."
+msgstr ""
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "Restarting..."
+msgstr ""
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "Rebooting..."
+msgstr ""
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "Restart"
 msgstr ""

--- a/web/src/locales/de.po
+++ b/web/src/locales/de.po
@@ -1970,11 +1970,9 @@ msgstr "Einrichtung abgeschlossen"
 msgid "A <0>full system reboot</0> is required for Sylve to finish initialization. Continue when ready."
 msgstr "Ein <0>vollständiger Systemneustart</0> ist erforderlich, damit Sylve die Initialisierung abschließen kann. Fortfahren, wenn Sie bereit sind."
 
-#: src/lib/components/custom/Initialization/Reboot.svelte
-msgid "<0/> Rebooting..."
-msgstr "<0/> Neustart..."
+#~ msgid "<0/> Rebooting..."
+#~ msgstr "<0/> Neustart..."
 
-#: src/lib/components/custom/Initialization/Reboot.svelte
 #: src/lib/components/skeleton/TreeViewCluster.svelte
 msgid "<0/> Reboot"
 msgstr "<0/> Neustart"
@@ -2765,6 +2763,7 @@ msgstr "Zwangslöschen"
 msgid "Running"
 msgstr "Läuft"
 
+#: src/lib/components/custom/Initialization/Reboot.svelte
 #: src/routes/[node]/vm/[rid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/summary/+page.svelte
 msgid "Reboot"
@@ -17068,4 +17067,28 @@ msgstr ""
 
 #: src/lib/components/custom/ZFS/datasets/snapshots/Retention.svelte
 msgid "Snapshot job is unavailable"
+msgstr ""
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "Sylve is restarting..."
+msgstr ""
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "Sylve is back online"
+msgstr ""
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "A <0>quick restart</0> is required for Sylve to finish initialization. Continue when ready."
+msgstr ""
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "Restarting..."
+msgstr ""
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "Rebooting..."
+msgstr ""
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "Restart"
 msgstr ""

--- a/web/src/locales/en.po
+++ b/web/src/locales/en.po
@@ -1970,11 +1970,9 @@ msgstr "Setup Complete"
 msgid "A <0>full system reboot</0> is required for Sylve to finish initialization. Continue when ready."
 msgstr "A <0>full system reboot</0> is required for Sylve to finish initialization. Continue when ready."
 
-#: src/lib/components/custom/Initialization/Reboot.svelte
-msgid "<0/> Rebooting..."
-msgstr "<0/> Rebooting..."
+#~ msgid "<0/> Rebooting..."
+#~ msgstr "<0/> Rebooting..."
 
-#: src/lib/components/custom/Initialization/Reboot.svelte
 #: src/lib/components/skeleton/TreeViewCluster.svelte
 msgid "<0/> Reboot"
 msgstr "<0/> Reboot"
@@ -2765,6 +2763,7 @@ msgstr "Force Delete"
 msgid "Running"
 msgstr "Running"
 
+#: src/lib/components/custom/Initialization/Reboot.svelte
 #: src/routes/[node]/vm/[rid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/summary/+page.svelte
 msgid "Reboot"
@@ -17069,3 +17068,27 @@ msgstr "Copy portal address {0}:{1}"
 #: src/lib/components/custom/ZFS/datasets/snapshots/Retention.svelte
 msgid "Snapshot job is unavailable"
 msgstr "Snapshot job is unavailable"
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "Sylve is restarting..."
+msgstr "Sylve is restarting..."
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "Sylve is back online"
+msgstr "Sylve is back online"
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "A <0>quick restart</0> is required for Sylve to finish initialization. Continue when ready."
+msgstr "A <0>quick restart</0> is required for Sylve to finish initialization. Continue when ready."
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "Restarting..."
+msgstr "Restarting..."
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "Rebooting..."
+msgstr "Rebooting..."
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "Restart"
+msgstr "Restart"

--- a/web/src/locales/hi.po
+++ b/web/src/locales/hi.po
@@ -1970,11 +1970,9 @@ msgstr "सेटअप पूरा हुआ"
 msgid "A <0>full system reboot</0> is required for Sylve to finish initialization. Continue when ready."
 msgstr "सिल्वे का इनिशियलाइज़ेशन पूरा करने के लिए <0>सिस्टम को पूर्ण रूप से रीबूट</0> करना आवश्यक है। तैयार होने पर जारी रखें।"
 
-#: src/lib/components/custom/Initialization/Reboot.svelte
-msgid "<0/> Rebooting..."
-msgstr "<0/> रीबूट हो रहा है..."
+#~ msgid "<0/> Rebooting..."
+#~ msgstr "<0/> रीबूट हो रहा है..."
 
-#: src/lib/components/custom/Initialization/Reboot.svelte
 #: src/lib/components/skeleton/TreeViewCluster.svelte
 msgid "<0/> Reboot"
 msgstr "<0/> रीबूट करें"
@@ -2765,6 +2763,7 @@ msgstr "जबरन हटाएँ"
 msgid "Running"
 msgstr "चल रहा है"
 
+#: src/lib/components/custom/Initialization/Reboot.svelte
 #: src/routes/[node]/vm/[rid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/summary/+page.svelte
 msgid "Reboot"
@@ -17068,4 +17067,28 @@ msgstr ""
 
 #: src/lib/components/custom/ZFS/datasets/snapshots/Retention.svelte
 msgid "Snapshot job is unavailable"
+msgstr ""
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "Sylve is restarting..."
+msgstr ""
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "Sylve is back online"
+msgstr ""
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "A <0>quick restart</0> is required for Sylve to finish initialization. Continue when ready."
+msgstr ""
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "Restarting..."
+msgstr ""
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "Rebooting..."
+msgstr ""
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "Restart"
 msgstr ""

--- a/web/src/locales/mal.po
+++ b/web/src/locales/mal.po
@@ -1970,11 +1970,9 @@ msgstr "സജ്ജീകരണം പൂർത്തിയായി"
 msgid "A <0>full system reboot</0> is required for Sylve to finish initialization. Continue when ready."
 msgstr "സിൽവ് സജ്ജീകരണം പൂർത്തിയാക്കാൻ ഒരു <0>പൂർണ്ണമായ സിസ്റ്റം റീബൂട്ട്</0> ആവശ്യമാണ്. തയ്യാറാകുമ്പോൾ തുടരുക."
 
-#: src/lib/components/custom/Initialization/Reboot.svelte
-msgid "<0/> Rebooting..."
-msgstr "<0/> റീബൂട്ട് ചെയ്യുന്നു..."
+#~ msgid "<0/> Rebooting..."
+#~ msgstr "<0/> റീബൂട്ട് ചെയ്യുന്നു..."
 
-#: src/lib/components/custom/Initialization/Reboot.svelte
 #: src/lib/components/skeleton/TreeViewCluster.svelte
 msgid "<0/> Reboot"
 msgstr "<0/> റീബൂട്ട്"
@@ -2765,6 +2763,7 @@ msgstr "നിർബന്ധിതമായി ഇല്ലാതാക്ക�
 msgid "Running"
 msgstr "പ്രവർത്തിക്കുന്നു"
 
+#: src/lib/components/custom/Initialization/Reboot.svelte
 #: src/routes/[node]/vm/[rid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/summary/+page.svelte
 msgid "Reboot"
@@ -17068,4 +17067,28 @@ msgstr ""
 
 #: src/lib/components/custom/ZFS/datasets/snapshots/Retention.svelte
 msgid "Snapshot job is unavailable"
+msgstr ""
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "Sylve is restarting..."
+msgstr ""
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "Sylve is back online"
+msgstr ""
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "A <0>quick restart</0> is required for Sylve to finish initialization. Continue when ready."
+msgstr ""
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "Restarting..."
+msgstr ""
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "Rebooting..."
+msgstr ""
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "Restart"
 msgstr ""

--- a/web/src/locales/zh-CN.po
+++ b/web/src/locales/zh-CN.po
@@ -1970,11 +1970,9 @@ msgstr "设置完成"
 msgid "A <0>full system reboot</0> is required for Sylve to finish initialization. Continue when ready."
 msgstr "Sylve 需要<0>完整系统重启</0>来完成初始化。准备就绪后请继续。"
 
-#: src/lib/components/custom/Initialization/Reboot.svelte
-msgid "<0/> Rebooting..."
-msgstr "<0/> 正在重启..."
+#~ msgid "<0/> Rebooting..."
+#~ msgstr "<0/> 正在重启..."
 
-#: src/lib/components/custom/Initialization/Reboot.svelte
 #: src/lib/components/skeleton/TreeViewCluster.svelte
 msgid "<0/> Reboot"
 msgstr "<0/> 重启"
@@ -2765,6 +2763,7 @@ msgstr "强制删除"
 msgid "Running"
 msgstr "正在运行"
 
+#: src/lib/components/custom/Initialization/Reboot.svelte
 #: src/routes/[node]/vm/[rid]/+layout.svelte
 #: src/routes/[node]/vm/[rid]/summary/+page.svelte
 msgid "Reboot"
@@ -17065,4 +17064,28 @@ msgstr ""
 
 #: src/lib/components/custom/ZFS/datasets/snapshots/Retention.svelte
 msgid "Snapshot job is unavailable"
+msgstr ""
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "Sylve is restarting..."
+msgstr ""
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "Sylve is back online"
+msgstr ""
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "A <0>quick restart</0> is required for Sylve to finish initialization. Continue when ready."
+msgstr ""
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "Restarting..."
+msgstr ""
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "Rebooting..."
+msgstr ""
+
+#: src/lib/components/custom/Initialization/Reboot.svelte
+msgid "Restart"
 msgstr ""


### PR DESCRIPTION
Jailed programs can never reboot the host: `PRIV_REBOOT` is not granted to jails, so `shutdown -r now` fails and hangs.

Detect the jail via `security.jail.jailed` sysctl, and when jailed, re-exec the process in place so it restarts within the same jail.  On non-jailed deployment, behavior is unchanged (`shutdown -r now`)

https://github.com/user-attachments/assets/9ca0f523-9b3d-453e-85f7-34535dcfac82
