### PR TITLE
libvirt: storage: fix StorageUpdate deadlock on DiskImage disks

### DIFF
--- a/internal/services/libvirt/libvirt_storage.go
+++ b/internal/services/libvirt/libvirt_storage.go
@@ -576,7 +576,7 @@ func (s *Service) syncVMDisksWithDB(ctx context.Context, db *gorm.DB, rid uint) 
 				)
 			}
 		} else if storage.Type == vmModels.VMStorageTypeDiskImage {
-			diskValue, err = s.FindISOByUUID(storage.DownloadUUID, true)
+			diskValue, err = s.findISOByUUIDWithDB(db, storage.DownloadUUID, true)
 			if err != nil {
 				return fmt.Errorf("failed_to_get_iso_path_by_uuid: %w", err)
 			}

--- a/internal/services/libvirt/libvirt_storage_iso_lookup_test.go
+++ b/internal/services/libvirt/libvirt_storage_iso_lookup_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Copyright (c) 2025 The FreeBSD Foundation.
+//
+// This software was developed by Hayzam Sherif <hayzam@alchemilla.io>
+// of Alchemilla Ventures Pvt. Ltd. <hello@alchemilla.io>,
+// under sponsorship from the FreeBSD Foundation.
+
+package libvirt
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/alchemillahq/sylve/internal/config"
+	utilitiesModels "github.com/alchemillahq/sylve/internal/db/models/utilities"
+	"github.com/alchemillahq/sylve/internal/testutil"
+	"gorm.io/gorm"
+)
+
+// TestFindISOByUUIDWithDB_UsesGivenHandleInsideTransaction is a regression
+// test for the StorageUpdate/syncVMDisksWithDB deadlock: it reproduces the
+// deadlock-prone environment (SQLite MaxOpenConns=1, running inside an open
+// transaction) and asserts the ISO lookup completes promptly instead of
+// blocking.
+func TestFindISOByUUIDWithDB_UsesGivenHandleInsideTransaction(t *testing.T) {
+	t.Setenv("SYLVE_DATA_PATH", t.TempDir())
+
+	db := testutil.NewSQLiteTestDB(t, &utilitiesModels.Downloads{}, &utilitiesModels.DownloadedFile{})
+	svc := &Service{DB: db}
+
+	const uuid = "storage-update-iso-lookup"
+	httpDir := config.GetDownloadsPath("http")
+	if err := os.MkdirAll(httpDir, 0o755); err != nil {
+		t.Fatalf("failed to create http downloads dir: %v", err)
+	}
+	isoPath := filepath.Join(httpDir, "test.iso")
+	if err := os.WriteFile(isoPath, []byte("iso"), 0o644); err != nil {
+		t.Fatalf("failed to create iso file: %v", err)
+	}
+
+	download := utilitiesModels.Downloads{
+		UUID:     uuid,
+		Path:     isoPath,
+		Name:     "test.iso",
+		Type:     utilitiesModels.DownloadTypeHTTP,
+		URL:      "https://example.invalid/test.iso",
+		Progress: 100,
+		Size:     3,
+		UType:    utilitiesModels.DownloadUTypeOther,
+		Status:   utilitiesModels.DownloadStatusDone,
+	}
+	if err := db.Create(&download).Error; err != nil {
+		t.Fatalf("failed to seed download row: %v", err)
+	}
+
+	txErr := db.Transaction(func(tx *gorm.DB) error {
+		type result struct {
+			path string
+			err  error
+		}
+		done := make(chan result, 1)
+
+		// Run the lookup on its own goroutine so a deadlock (blocking
+		// forever waiting for a second SQLite connection) fails this test
+		// instead of hanging the whole test binary.
+		go func() {
+			path, err := svc.findISOByUUIDWithDB(tx, uuid, true)
+			done <- result{path, err}
+		}()
+
+		select {
+		case r := <-done:
+			if r.err != nil {
+				return r.err
+			}
+			if r.path != isoPath {
+				t.Fatalf("isoPath = %q, want %q", r.path, isoPath)
+			}
+			return nil
+		case <-time.After(2 * time.Second):
+			t.Fatal("findISOByUUIDWithDB(tx, ...) deadlocked when called from inside " +
+				"an open transaction with a single-connection pool; this is the " +
+				"StorageUpdate/syncVMDisksWithDB hang this test guards against")
+			return nil
+		}
+	})
+	if txErr != nil {
+		t.Fatalf("transaction failed: %v", txErr)
+	}
+}

--- a/internal/services/libvirt/libvirt_utils.go
+++ b/internal/services/libvirt/libvirt_utils.go
@@ -26,6 +26,7 @@ import (
 	"github.com/alchemillahq/sylve/pkg/utils"
 	"github.com/digitalocean/go-libvirt"
 	"github.com/klauspost/cpuid/v2"
+	"gorm.io/gorm"
 )
 
 var flashImageToDiskCtx = utils.FlashImageToDiskCtx
@@ -115,9 +116,16 @@ func domainReasonToString(state libvirt.DomainState, reason int32) libvirtServic
 	}
 }
 
+// FindISOByUUID resolves the on-disk path for a download UUID.
 func (s *Service) FindISOByUUID(uuid string, includeImg bool) (string, error) {
+	return s.findISOByUUIDWithDB(s.DB, uuid, includeImg)
+}
+
+// findISOByUUIDWithDB is FindISOByUUID with an explicit db handle, for
+// callers running inside a DB transaction.
+func (s *Service) findISOByUUIDWithDB(db *gorm.DB, uuid string, includeImg bool) (string, error) {
 	var download utilitiesModels.Downloads
-	if err := s.DB.
+	if err := db.
 		Preload("Files").
 		Where("uuid = ?", uuid).
 		First(&download).Error; err != nil {


### PR DESCRIPTION
## Summary

`syncVMDisksWithDB` (invoked from `StorageUpdate` inside a DB transaction) resolves a DiskImage storage's backing ISO path via `FindISOByUUID`, which always queries through the service's pooled DB connection (`s.DB`) instead of the transaction handle it was actually given (`db`). With SQLite's default single-connection pool, calling `FindISOByUUID` from inside an open `db.Transaction` blocks forever waiting for a second connection that the outer transaction is already holding — deadlocking the whole database. Every other request sharing the same connection pool hangs too, not just the `StorageUpdate` call that triggered it.

## Reproduction

Confirmed live on a real host: `PATCH /vm/:rid/storage/:storageId` on an ISO/DiskImage storage hung indefinitely, and unrelated background jobs (the ZFS pool cron tick) started timing out with `context deadline exceeded" on a plain `SELECT * FROM basic_settings` shortly after — the whole SQLite connection pool was wedged. Only restarting the process cleared it.

A goroutine dump of the hung process pointed straight at the bug:

```
database/sql.(*DB).conn(...)
...
github.com/alchemillahq/sylve/internal/services/libvirt.(*Service).FindISOByUUID(...)
	internal/services/libvirt/libvirt_utils.go:123
github.com/alchemillahq/sylve/internal/services/libvirt.(*Service).syncVMDisksWithDB(...)
	internal/services/libvirt/libvirt_storage.go:579
github.com/alchemillahq/sylve/internal/services/libvirt.(*Service).StorageUpdate.func1(...)
	internal/services/libvirt/libvirt_storage.go:1843
```

## Fix

- Add `findISOByUUIDWithDB`, which takes an explicit `*gorm.DB` handle.
- `syncVMDisksWithDB` now calls `findISOByUUIDWithDB(db, ...)` with the `db` parameter it already receives, instead of `FindISOByUUID` (which always uses `s.DB`).
- `FindISOByUUID`'s public signature is unchanged; it now delegates to `findISOByUUIDWithDB(s.DB, ...)`, so its other call sites (outside a transaction) are unaffected.

## Testing

Added `TestFindISOByUUIDWithDB_UsesGivenHandleInsideTransaction`, which reproduces the deadlock-prone environment (SQLite `MaxOpenConns(1)`, running inside an open `db.Transaction`) and asserts the lookup completes promptly instead of blocking (bounded with a timeout so a regression fails the test instead of hanging the suite).

`go build ./...` and the full `go test -short ./...` suite pass on FreeBSD 15.1-amd64 (one pre-existing, unrelated failure in `pkg/network/mdns` — a hostname-format assumption in `TestBrowse` that also fails on a clean checkout of `master`, confirmed before filing this PR).